### PR TITLE
Add more info on tinc

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Nix:
 
 * [`tinc`](https://github.com/sol/tinc/blob/nixpkgs/NIX.md) - this uses
   `cabal`'s solver to select which Haskell packages to use instead of the
-  curated Haskell package set from `nixpkgs`
+  curated Haskell package set from `nixpkgs`. Stack's curated package set can be used as well.
 * [`styx`](https://github.com/jyp/styx) - This tool provides a `stack`-like
   interface to managing Haskell dependencies using Nix
 


### PR DESCRIPTION
I just realized it is possible to use Stack's curated package set with `tinc` as well. Simply download `cabal.config` from stackage.org. More details at same documentation link. Feel free to reword this as you see fit.